### PR TITLE
Fix README and tests for generic connections and add example

### DIFF
--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -1,15 +1,3 @@
-r2d2-diesel
-===========
-
-Provides [r2d2](https://github.com/sfackler/r2d2) support to allow connection pooling with Diesel.
-
-Example
-=======
-
-This example creates a connection pool with default settings for a PostgreSQL database running on localhost, then creates a bunch of threads and acquires a connection from the pool for each thread.
-An executable version of this example is in [examples/postgres.rs](examples/postgres.rs) which you can run with `cargo run --example postgres`.
-
-```rust
 extern crate diesel;
 extern crate r2d2;
 extern crate r2d2_diesel;
@@ -33,4 +21,3 @@ fn main() {
         });
     }
 }
-```

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,14 +1,17 @@
+extern crate diesel;
 extern crate r2d2;
 extern crate r2d2_diesel;
 
 use std::sync::Arc;
 use std::sync::mpsc;
 use std::thread;
+
+use diesel::pg::PgConnection;
 use r2d2_diesel::ConnectionManager;
 
 #[test]
 fn basic_connection() {
-    let manager = ConnectionManager::new("postgres://localhost");
+    let manager = ConnectionManager::<PgConnection>::new("postgres://localhost/");
     let config = r2d2::Config::builder().pool_size(2).build();
     let pool = Arc::new(r2d2::Pool::new(config, manager).unwrap());
 
@@ -39,7 +42,7 @@ fn basic_connection() {
 
 #[test]
 fn is_valid() {
-    let manager = ConnectionManager::new("postgres://localhost");
+    let manager = ConnectionManager::<PgConnection>::new("postgres://localhost/");
     let config = r2d2::Config::builder().pool_size(1).test_on_check_out(true).build();
     let pool = r2d2::Pool::new(config, manager).unwrap();
 


### PR DESCRIPTION
Adds a fix to the README about the lib being PG-specific, plus updated tests and an executable version of the README example.
