### PR TITLE
fix: don't use default-features for diesel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/sgrif/r2d2-diesel"
 
 [dependencies]
 r2d2 = "0.7.0"
-diesel = ">= 0.5.0, < 0.10.0"
+diesel = { version = ">= 0.5.0, < 0.10.0", default-features = false }
 
 [features]
-default = []
+default = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]


### PR DESCRIPTION
I was trying to build for r2d2-diesel for sqlite, but ran into the `pq-sys` dependency being pulled in which seems to be because diesel (the released version, not master) has postgres on by default.