### PR TITLE
support diesel 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ r2d2 = "0.7.0"
 diesel = ">= 0.5.0, < 0.11.0"
 
 [features]
-default = []
+default = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]


### PR DESCRIPTION
because of diesel 0.10 make postgres as a feature, r2d2-diesel must assign it