### PR TITLE
Bump r2d2 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ homepage = "https://github.com/sgrif/r2d2-diesel"
 repository = "https://github.com/sgrif/r2d2-diesel"
 
 [dependencies]
-r2d2 = "0.7.0"
+r2d2 = ">= 0.7, < 0.9"
 diesel = ">= 0.5.0, < 0.17.0"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ use diesel::pg::PgConnection;
 use r2d2_diesel::ConnectionManager;
 
 fn main() {
-    let config = r2d2::Config::default();
     let manager = ConnectionManager::<PgConnection>::new("postgres://localhost/");
-    let pool = r2d2::Pool::new(config, manager).expect("Failed to create pool.");
+    let pool = r2d2::Pool::builder().build(manager).expect("Failed to create pool.");
 
     for _ in 0..10i32 {
         let pool = pool.clone();

--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -8,9 +8,8 @@ use diesel::pg::PgConnection;
 use r2d2_diesel::ConnectionManager;
 
 fn main() {
-    let config = r2d2::Config::default();
     let manager = ConnectionManager::<PgConnection>::new("postgres://localhost/");
-    let pool = r2d2::Pool::new(config, manager).expect("Failed to create pool.");
+    let pool = r2d2::Pool::builder().build(manager).expect("Failed to create pool.");
 
     for _ in 0..10i32 {
         let pool = pool.clone();

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -8,9 +8,8 @@ use diesel::sqlite::SqliteConnection;
 use r2d2_diesel::ConnectionManager;
 
 fn main() {
-    let config = r2d2::Config::default();
     let manager = ConnectionManager::<SqliteConnection>::new("db.sqlite");
-    let pool = r2d2::Pool::new(config, manager).expect("Failed to create pool.");
+    let pool = r2d2::Pool::builder().build(manager).expect("Failed to create pool.");
 
     for _ in 0..10i32 {
         let pool = pool.clone();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,8 +13,7 @@ use r2d2_diesel::ConnectionManager;
 #[test]
 fn pg_basic_connection() {
     let manager = ConnectionManager::<PgConnection>::new("postgres://localhost/");
-    let config = r2d2::Config::builder().pool_size(2).build();
-    let pool = Arc::new(r2d2::Pool::new(config, manager).unwrap());
+    let pool = Arc::new(r2d2::Pool::builder().max_size(2).build(manager).unwrap());
 
     let (s1, r1) = mpsc::channel();
     let (s2, r2) = mpsc::channel();
@@ -44,8 +43,7 @@ fn pg_basic_connection() {
 #[test]
 fn pg_is_valid() {
     let manager = ConnectionManager::<PgConnection>::new("postgres://localhost/");
-    let config = r2d2::Config::builder().pool_size(1).test_on_check_out(true).build();
-    let pool = r2d2::Pool::new(config, manager).unwrap();
+    let pool = r2d2::Pool::builder().max_size(1).test_on_check_out(true).build(manager).unwrap();
 
     pool.get().unwrap();
 }
@@ -53,8 +51,7 @@ fn pg_is_valid() {
 #[test]
 fn sqlite_basic_connection() {
     let manager = ConnectionManager::<SqliteConnection>::new("test.db");
-    let config = r2d2::Config::builder().pool_size(2).build();
-    let pool = Arc::new(r2d2::Pool::new(config, manager).unwrap());
+    let pool = Arc::new(r2d2::Pool::builder().max_size(2).build(manager).unwrap());
 
     let (s1, r1) = mpsc::channel();
     let (s2, r2) = mpsc::channel();
@@ -84,8 +81,7 @@ fn sqlite_basic_connection() {
 #[test]
 fn sqlite_is_valid() {
     let manager = ConnectionManager::<SqliteConnection>::new("test.db");
-    let config = r2d2::Config::builder().pool_size(1).test_on_check_out(true).build();
-    let pool = r2d2::Pool::new(config, manager).unwrap();
+    let pool = r2d2::Pool::builder().max_size(1).test_on_check_out(true).build(manager).unwrap();
 
     pool.get().unwrap();
 }


### PR DESCRIPTION
It went from having to create a Config struct and passing it to
`Pool::new` to the builder pattern. The `pool_size` setting has been
renamed to `max_size` too.