### PR TITLE
Fix examples && Add new_with_init_operations function for ConnectionManager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ repository = "https://github.com/sgrif/r2d2-diesel"
 [dependencies]
 r2d2 = ">= 0.7, < 0.9"
 diesel = "1.0"
+
+[dev-dependencies]
+r2d2 = ">= 0.8, < 0.9"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,48 @@ fn main() {
 }
 ```
 
+Or you may need some extra operations after establishing a connection
+```rust
+extern crate diesel;
+extern crate r2d2;
+extern crate r2d2_diesel;
+
+use std::thread;
+use diesel::Connection;
+use diesel::RunQueryDsl;
+use diesel::types::Text;
+use diesel::expression::sql_literal::sql;
+use diesel::sqlite::SqliteConnection;
+use r2d2_diesel::{ConnectionManager, Error};
+
+const CACHE_SIZE: &'static str = "4000";
+fn init_operations(connection: &SqliteConnection) -> Result<(), Error> {
+    let query = format!("PRAGMA CACHE_SIZE = {}", CACHE_SIZE);
+    connection.execute(&query).map_err(Error::QueryError)?;
+
+    Ok(())
+}
+
+fn main() {
+    let manager =
+        ConnectionManager::<SqliteConnection>::new_with_init_operations("db.sqlite",
+                                                                        Box::new(init_operations));
+    let pool = r2d2::Pool::builder().build(manager).expect("Failed to create pool.");
+
+    for _ in 0..10i32 {
+        let pool = pool.clone();
+        thread::spawn(move || {
+            let query = "PRAGMA CACHE_SIZE";
+            let connection = pool.get().expect("Failed to get pooled connection");
+            let cache_size = sql::<Text>(&query).load::<String>(&*connection)
+                .expect("Failed to get cache size").pop();
+
+            assert_eq!(Some(CACHE_SIZE.to_owned()), cache_size);
+        });
+    }
+}
+```
+
 Using diesel master branch
 ============================
 

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -3,11 +3,19 @@ extern crate r2d2;
 extern crate r2d2_diesel;
 
 use std::thread;
-
+use diesel::Connection;
+use diesel::RunQueryDsl;
+use diesel::types::Text;
+use diesel::expression::sql_literal::sql;
 use diesel::sqlite::SqliteConnection;
-use r2d2_diesel::ConnectionManager;
+use r2d2_diesel::{ConnectionManager, Error};
 
 fn main() {
+    new_pool();
+    new_pool_with_init_operations();
+}
+
+fn new_pool() {
     let manager = ConnectionManager::<SqliteConnection>::new("db.sqlite");
     let pool = r2d2::Pool::builder().build(manager).expect("Failed to create pool.");
 
@@ -17,6 +25,33 @@ fn main() {
             let connection = pool.get();
 
             assert!(connection.is_ok());
+        });
+    }
+}
+
+const CACHE_SIZE: &'static str = "4000";
+fn init_operations(connection: &SqliteConnection) -> Result<(), Error> {
+    let query = format!("PRAGMA CACHE_SIZE = {}", CACHE_SIZE);
+    connection.execute(&query).map_err(Error::QueryError)?;
+
+    Ok(())
+}
+
+fn new_pool_with_init_operations() {
+    let manager =
+        ConnectionManager::<SqliteConnection>::new_with_init_operations("db.sqlite",
+                                                                        Box::new(init_operations));
+    let pool = r2d2::Pool::builder().build(manager).expect("Failed to create pool.");
+
+    for _ in 0..10i32 {
+        let pool = pool.clone();
+        thread::spawn(move || {
+            let query = "PRAGMA CACHE_SIZE";
+            let connection = pool.get().expect("Failed to get pooled connection");
+            let cache_size = sql::<Text>(&query).load::<String>(&*connection)
+                .expect("Failed to get cache size").pop();
+
+            assert_eq!(Some(CACHE_SIZE.to_owned()), cache_size);
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,16 +9,35 @@ use std::marker::PhantomData;
 
 pub struct ConnectionManager<T> {
     database_url: String,
+    init_operations: Option<BoxedInitOperations<T>>,
     _marker: PhantomData<T>,
 }
 
 unsafe impl<T: Send + 'static> Sync for ConnectionManager<T> {
 }
 
+pub trait InitOperations<T>: Fn(&T) -> Result<(), Error> + Sync + 'static + Send {}
+impl<T, F> InitOperations<T> for F where F: Fn(&T) -> Result<(), Error> + Sync + 'static + Send {}
+pub type BoxedInitOperations<T> = Box<InitOperations<T, Output=Result<(), Error>>>;
+
 impl<T> ConnectionManager<T> {
-    pub fn new<S: Into<String>>(database_url: S) -> Self {
+    pub fn new<S: Into<String>>(database_url: S) -> Self
+    {
         ConnectionManager {
             database_url: database_url.into(),
+            init_operations: None,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn new_with_init_operations<S: Into<String>>(
+        database_url: S,
+        init_operations: BoxedInitOperations<T>
+    ) -> Self
+    {
+        ConnectionManager {
+            database_url: database_url.into(),
+            init_operations: Some(init_operations),
             _marker: PhantomData,
         }
     }
@@ -55,8 +74,12 @@ impl<T> ManageConnection for ConnectionManager<T> where
     type Error = Error;
 
     fn connect(&self) -> Result<T, Error> {
-        T::establish(&self.database_url)
-            .map_err(Error::ConnectionError)
+        let conn = T::establish(&self.database_url).map_err(Error::ConnectionError)?;
+        if let Some(init_operations) = self.init_operations.as_ref() {
+            init_operations(&conn)?;
+        }
+
+        Ok(conn)
     }
 
     fn is_valid(&self, conn: &mut T) -> Result<(), Error> {


### PR DESCRIPTION
The Pool::builder() is added in version 0.8.0 of r2d2, but the r2d2 version in Cargo.toml is >= 0.7, < 0.9.
Sometimes we may need to do some initial operations for each connection, such as change the cache size for each SQLite connection. We can do some extra works after establishing a connection by using the new_with_init_operations to create a ConnectionManager