### PR TITLE
allow to pass init_queries executed for each new connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::marker::PhantomData;
 
 pub struct ConnectionManager<T> {
     database_url: String,
+    init_queries: Option<Vec<String>>,
     _marker: PhantomData<T>,
 }
 
@@ -19,9 +20,19 @@ impl<T> ConnectionManager<T> {
     pub fn new<S: Into<String>>(database_url: S) -> Self {
         ConnectionManager {
             database_url: database_url.into(),
+            init_queries: None,
             _marker: PhantomData,
         }
     }
+
+    pub fn new_with_init_queries<S: Into<String>>(database_url: S, init_queries: Option<Vec<String>>) -> Self {
+        ConnectionManager {
+            database_url: database_url.into(),
+            init_queries: init_queries,
+            _marker: PhantomData,
+        }
+    }
+
 }
 
 #[derive(Debug)]
@@ -55,8 +66,17 @@ impl<T> ManageConnection for ConnectionManager<T> where
     type Error = Error;
 
     fn connect(&self) -> Result<T, Error> {
-        T::establish(&self.database_url)
-            .map_err(Error::ConnectionError)
+        let conn = T::establish(&self.database_url)
+            .map_err(Error::ConnectionError);
+        if let (&Some(ref init_queries), &Ok(ref connection)) = (&self.init_queries, &conn) {
+            for init_query in init_queries {
+                match connection.batch_execute(init_query) {
+                    Ok(_) => {},
+                    Err(err) => return Err(Error::QueryError(err))
+                }
+            }
+        }
+        conn
     }
 
     fn is_valid(&self, conn: &mut T) -> Result<(), Error> {


### PR DESCRIPTION
I often need to set up connection (set strict mode, set session variables etc.), so having connection pool do it for me seems handy